### PR TITLE
Add SART contacts

### DIFF
--- a/src/Buoy.cpp
+++ b/src/Buoy.cpp
@@ -204,6 +204,7 @@ RadarData Buoy::getRadarData(irr::core::vector3df scannerPosition) const
     radarData.hidden=false;
     radarData.SART=false;
 
+    radarData.contactType = buoyContact;
     radarData.contact = (void*)this;
 
     return radarData;

--- a/src/NetworkPrimary.cpp
+++ b/src/NetworkPrimary.cpp
@@ -526,7 +526,7 @@ std::string NetworkPrimary::generateSendString()
     stringToSend.append(Utilities::lexical_cast<std::string>(model->getLines()->getNumberOfLines()));
     stringToSend.append("#");
 
-    //3 Each 'Other' (Pos X (abs), Pos Z, angle, rate of turn, SART, MMSI |) #
+    //3 Each 'Other' (Pos X (abs), Pos Z, angle, speed, rate of turn, SART, MMSI |) #
     for(int number = 0; number < (int)model->getNumberOfOtherShips(); number++ ) {
         stringToSend.append(Utilities::lexical_cast<std::string>(model->getOtherShipPosX(number)));
         stringToSend.append(",");
@@ -538,7 +538,14 @@ std::string NetworkPrimary::generateSendString()
         stringToSend.append(",");
         stringToSend.append("0"); // Rate of turn: This is not currently used in normal mode
         stringToSend.append(",");
-        stringToSend.append("0"); //Fixme: Sart enabled
+        
+        if (model->getOtherShipSARTOn(number)) {
+            stringToSend.append("1"); // Sart enabled
+        }
+        else {
+            stringToSend.append("0"); // Sart disabled
+        }
+        
         stringToSend.append(",");
         stringToSend.append(Utilities::lexical_cast<std::string>(model->getOtherShipMMSI(number)));
         stringToSend.append(",");

--- a/src/NetworkPrimary.cpp
+++ b/src/NetworkPrimary.cpp
@@ -382,6 +382,20 @@ void NetworkPrimary::receiveNetwork()
                                                 model->setSternThruster(overrideData);
                                             }
                                         }
+                                    } else if (thisCommand.substr(0, 2).compare("SR") == 0) {
+                                        //'SR', Set SART status
+                                        std::vector<std::string> parts = Utilities::split(thisCommand, ','); //Split into parts, 1st is command itself, 2nd and greater is the data
+                                        if (parts.size() == 3) {
+                                            int shipNo = Utilities::lexical_cast<int>(parts.at(1)) - 1; //Numbering on network starts at 1, internal numbering at 0
+                                            bool sartStatus;
+                                            if (parts.at(2) == "1") {
+                                                sartStatus = true;
+                                            }
+                                            else {
+                                                sartStatus = false;
+                                            }
+                                            model->setOtherShipSARTOn(shipNo, sartStatus);
+                                        }
                                     }
 
 

--- a/src/NetworkSecondary.cpp
+++ b/src/NetworkSecondary.cpp
@@ -244,8 +244,15 @@ void NetworkSecondary::receiveMessage()
                                 irr::f32 receivedPosX = Utilities::lexical_cast<irr::f32>(thisShipData.at(0));
                                 irr::f32 receivedPosZ = Utilities::lexical_cast<irr::f32>(thisShipData.at(1));
                                 model->setOtherShipPos(i,receivedPosX,receivedPosZ);
+
+                                // SART status
+                                if (thisShipData.at(5) == "1") {
+                                    model->setOtherShipSARTOn(i,true);
+                                } else {
+                                    model->setOtherShipSARTOn(i,false);
+                                }
                                 //Todo: Think about using timeError to extrapolate position to get more accurately.
-                                //Todo: use SART etc
+                                
                             }
                         }
                     }

--- a/src/NetworkSecondary.cpp
+++ b/src/NetworkSecondary.cpp
@@ -100,7 +100,8 @@ void NetworkSecondary::getScenarioFromNetwork(std::string& dataString) //Not use
                 if ((receivedString.substr(0,4) == "SCN1") || 
                     (receivedString.substr(0,4) == "SCN2") ||
                     (receivedString.substr(0,4) == "SCN3") ||
-                    (receivedString.substr(0,4) == "SCN4")) { //Check if it starts with SCN1-SCN4
+                    (receivedString.substr(0,4) == "SCN4") ||
+                    (receivedString.substr(0,4) == "SCN5")) { //Check if it starts with SCN1-SCN5
                     //If valid, use this string
                     dataString = receivedString;
                 }

--- a/src/OtherShip.cpp
+++ b/src/OtherShip.cpp
@@ -44,7 +44,11 @@ OtherShip::OtherShip (const std::string& name, const std::string& internalName, 
     this->drifting = drifting;
 
     // Set if SART is enabled - TODO, make this configurable
-    SART = true;
+    if (name == "Timbercarrier") {
+        SART = true;
+    } else {
+        SART = false;
+    }
     SARTtimeStamp = 0;
 
     std::string basePath = "Models/Othership/" + name + "/";
@@ -427,6 +431,16 @@ void OtherShip::setRateOfTurn(irr::f32 rateOfTurn) //Sets the rate of turn (only
 void OtherShip::setSARTtimeStamp(uint64_t timeStamp)
 {
     SARTtimeStamp = timeStamp;
+}
+
+bool OtherShip::getSARTOn() const
+{
+    return SART;
+}
+
+void OtherShip::setSARTOn(bool sartState)
+{
+    SART = sartState;
 }
 
 RadarData OtherShip::getRadarData(irr::core::vector3df scannerPosition) const

--- a/src/OtherShip.cpp
+++ b/src/OtherShip.cpp
@@ -43,6 +43,10 @@ OtherShip::OtherShip (const std::string& name, const std::string& internalName, 
     this->mmsi = mmsi;
     this->drifting = drifting;
 
+    // Set if SART is enabled - TODO, make this configurable
+    SART = true;
+    SARTtimeStamp = 0;
+
     std::string basePath = "Models/Othership/" + name + "/";
     std::string userFolder = Utilities::getUserDir();
     //Read model from user dir if it exists there.
@@ -420,6 +424,11 @@ void OtherShip::setRateOfTurn(irr::f32 rateOfTurn) //Sets the rate of turn (only
     this->rateOfTurn = rateOfTurn;
 }
 
+void OtherShip::setSARTtimeStamp(uint64_t timeStamp)
+{
+    SARTtimeStamp = timeStamp;
+}
+
 RadarData OtherShip::getRadarData(irr::core::vector3df scannerPosition) const
 //Get data for OtherShip (number) relative to scannerPosition
 //Similar code in Buoy.cpp
@@ -452,10 +461,11 @@ RadarData OtherShip::getRadarData(irr::core::vector3df scannerPosition) const
     radarData.minAngle=std::min(relAngle1,relAngle2);
     radarData.maxAngle=std::max(relAngle1,relAngle2);
 
-    //Initial defaults: Fixme: Will need changing with full implementation
     radarData.hidden=false;
-    radarData.SART=false;
+    radarData.SART=SART;
+    radarData.SARTtimeStamp = SARTtimeStamp;
 
+    radarData.contactType = otherShipContact;
     radarData.contact = (void*)this;
 
     return radarData;

--- a/src/OtherShip.cpp
+++ b/src/OtherShip.cpp
@@ -29,7 +29,7 @@
 
 //using namespace irr;
 
-OtherShip::OtherShip (const std::string& name, const std::string& internalName, const irr::u32& mmsi, const irr::core::vector3df& location, std::vector<Leg> legsLoaded, bool drifting, SimulationModel* model, irr::scene::ISceneManager* smgr, irr::IrrlichtDevice* dev)
+OtherShip::OtherShip (const std::string& name, const std::string& internalName, const irr::u32& mmsi, const irr::core::vector3df& location, std::vector<Leg> legsLoaded, bool drifting, bool SART, SimulationModel* model, irr::scene::ISceneManager* smgr, irr::IrrlichtDevice* dev)
 {
 
     //Initialise speed and heading, normally updated from leg information
@@ -42,13 +42,8 @@ OtherShip::OtherShip (const std::string& name, const std::string& internalName, 
     this->name = name;
     this->mmsi = mmsi;
     this->drifting = drifting;
+    this->SART = SART;
 
-    // Set if SART is enabled - TODO, make this configurable
-    if (name == "Timbercarrier") {
-        SART = true;
-    } else {
-        SART = false;
-    }
     SARTtimeStamp = 0;
 
     std::string basePath = "Models/Othership/" + name + "/";

--- a/src/OtherShip.hpp
+++ b/src/OtherShip.hpp
@@ -50,6 +50,8 @@ class OtherShip : public Ship
         void enableTriangleSelector(bool selectorEnabled);
         void setRateOfTurn(irr::f32 rateOfTurn); // This could be moved to Ship.hpp
         void setSARTtimeStamp(uint64_t timeStamp);
+        bool getSARTOn() const;
+        void setSARTOn(bool sartState);
 
     protected:
     private:

--- a/src/OtherShip.hpp
+++ b/src/OtherShip.hpp
@@ -49,6 +49,7 @@ class OtherShip : public Ship
         void update(irr::f32 deltaTime, irr::f32 scenarioTime, irr::f32 tideHeight, irr::u32 lightLevel);
         void enableTriangleSelector(bool selectorEnabled);
         void setRateOfTurn(irr::f32 rateOfTurn); // This could be moved to Ship.hpp
+        void setSARTtimeStamp(uint64_t timeStamp);
 
     protected:
     private:
@@ -65,6 +66,8 @@ class OtherShip : public Ship
         irr::scene::ITriangleSelector* selector;
         bool triangleSelectorEnabled;
         bool drifting;
+        bool SART; // If SART is enabled
+        uint64_t SARTtimeStamp;
 };
 
 #endif

--- a/src/OtherShip.hpp
+++ b/src/OtherShip.hpp
@@ -26,6 +26,7 @@
 
 #include <cmath>
 #include <vector>
+#include <cstdint> // for uint64_t
 
 // Forward declarations
 class SimulationModel;

--- a/src/OtherShip.hpp
+++ b/src/OtherShip.hpp
@@ -34,7 +34,7 @@ struct RadarData;
 class OtherShip : public Ship
 {
     public:
-        OtherShip (const std::string& name, const std::string& internalName, const irr::u32& mmsi, const irr::core::vector3df& location, std::vector<Leg> legsLoaded, bool drifting, SimulationModel* model, irr::scene::ISceneManager* smgr, irr::IrrlichtDevice* dev);
+        OtherShip (const std::string& name, const std::string& internalName, const irr::u32& mmsi, const irr::core::vector3df& location, std::vector<Leg> legsLoaded, bool drifting, bool SART, SimulationModel* model, irr::scene::ISceneManager* smgr, irr::IrrlichtDevice* dev);
         ~OtherShip();
 
         irr::f32 getHeight() const;

--- a/src/OtherShips.cpp
+++ b/src/OtherShips.cpp
@@ -214,6 +214,23 @@ irr::f32 OtherShips::getEstimatedDisplacement(int number) const
     }
 }
 
+bool OtherShips::getSARTOn(int number) const
+{
+    if (number < (int)otherShips.size() && number >= 0) {
+        return otherShips.at(number)->getSARTOn();
+    }
+    else {
+        return false;
+    }
+}
+
+void OtherShips::setSARTOn(int number, bool sartState)
+{
+    if (number < (int)otherShips.size() && number >= 0) {
+        otherShips.at(number)->setSARTOn(sartState);
+    }
+}
+
 void OtherShips::setSpeed(int number, irr::f32 speed)
 {
     if (number < (int)otherShips.size() && number >= 0) {

--- a/src/OtherShips.cpp
+++ b/src/OtherShips.cpp
@@ -60,6 +60,9 @@ void OtherShips::load(std::vector<OtherShipData> otherShipsData, irr::f32 scenar
         //Set if it's drifting with wind/stream
         bool drifting = otherShipsData.at(i).drifting;
 
+        // Set if SART is on
+        bool SART = otherShipsData.at(i).SART;
+
         //Load leg information
         std::vector<Leg> legs;
         irr::f32 legStartTime = scenarioStartTime;
@@ -92,7 +95,7 @@ void OtherShips::load(std::vector<OtherShipData> otherShipsData, irr::f32 scenar
         //Create otherShip and load into vector
         std::string internalName = "OtherShip_";
         internalName.append(std::to_string(i));
-        otherShips.push_back(new OtherShip (otherShipName,internalName,mmsi,irr::core::vector3df(shipX,0.0f,shipZ),legs,drifting,model,smgr, dev));
+        otherShips.push_back(new OtherShip (otherShipName,internalName,mmsi,irr::core::vector3df(shipX,0.0f,shipZ),legs,drifting,SART,model,smgr, dev));
     }
 
 }

--- a/src/OtherShips.hpp
+++ b/src/OtherShips.hpp
@@ -47,6 +47,8 @@ class OtherShips
         irr::f32 getSpeed(int number) const; //Speed in m/s
         irr::u32 getMMSI(int number) const;
         irr::f32 getEstimatedDisplacement(int number) const;
+        bool getSARTOn(int number) const;
+        void setSARTOn(int number, bool sartState);
         void setSpeed(int number, irr::f32 speed); //Speed in m/s
         void setMMSI(int number, irr::u32 mmsi);
         void setPos(int number, irr::f32 positionX, irr::f32 positionZ);

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -1398,21 +1398,38 @@ irr::f32 RadarCalculation::getSARTStrength(irr::f32 radarFactorSART, irr::f32 sa
 
     irr::f32 returnStrength = 0;
     
-    // Main returns:
-    irr::f32 mainReturnStart = 0.3 * M_IN_NM; // Dependent on receiving radar tuning within SART sweep
-    irr::f32 mainReturnSpacing = 0.64 * M_IN_NM; // Set by SART sweep time
+    irr::f32 mainReturnStart = 0.32 * M_IN_NM; // Dependent on receiving radar tuning within SART sweep
+    irr::f32 additionalReturnStart = 100; // Dependent on response time and fast response speed. IMO SN/Circ. 197 says no more than 150m
+    irr::f32 returnSpacing = 0.64 * M_IN_NM; // Set by SART sweep time
     irr::f32 mainReturnLength = 0.1 * M_IN_NM; // Factor to account for how long SART pulse is within bandwidth;
-    int numberOfMainReturns = 12;
-    irr::f32 mainReturnEnd = mainReturnStart + mainReturnSpacing * (numberOfMainReturns - 1);
+    irr::f32 additionalReturnLength = 0.05 * M_IN_NM; // Factor to account for how long SART pulse is within bandwidth;
+    irr::f32 additionalReturnFactor = 0.01; // Scaling factor so additional returns only show when close
+    int numberOfReturns = 12;
+    irr::f32 mainReturnEnd = mainReturnStart + returnSpacing * (numberOfReturns - 1);
+    irr::f32 additionalReturnEnd = additionalReturnStart + returnSpacing * (numberOfReturns - 1);
 
+    // Main returns: 
     if ((relativeSARTRange >= mainReturnStart - 0.5 * mainReturnLength) && (relativeSARTRange <= mainReturnEnd + 0.5 * mainReturnLength)) {
-        for (int i = 0; i < numberOfMainReturns; i++) {
-            irr::f32 thisReturnDist = mainReturnStart + i * mainReturnSpacing;
+        for (int i = 0; i < numberOfReturns; i++) {
+            irr::f32 thisReturnDist = mainReturnStart + i * returnSpacing;
             irr::f32 thisReturnDistMin = thisReturnDist - mainReturnLength / 2;
             irr::f32 thisReturnDistMax = thisReturnDistMin + mainReturnLength;
 
             if ((relativeSARTRange >= thisReturnDistMin) && (relativeSARTRange <= thisReturnDistMax)) {
                 returnStrength += angleFactor * sartEchoStrength;
+            }
+        }
+    }
+
+    // Additional returns: 
+    if ((relativeSARTRange >= additionalReturnStart - 0.5 * additionalReturnLength) && (relativeSARTRange <= additionalReturnEnd + 0.5 * additionalReturnLength)) {
+        for (int i = 0; i < numberOfReturns; i++) {
+            irr::f32 thisReturnDist = additionalReturnStart + i * returnSpacing;
+            irr::f32 thisReturnDistMin = thisReturnDist - additionalReturnLength / 2;
+            irr::f32 thisReturnDistMax = thisReturnDistMin + additionalReturnLength;
+
+            if ((relativeSARTRange >= thisReturnDistMin) && (relativeSARTRange <= thisReturnDistMax)) {
+                returnStrength += angleFactor * sartEchoStrength * additionalReturnFactor;
             }
         }
     }

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -20,6 +20,7 @@
 #include "OwnShip.hpp"
 #include "Buoys.hpp"
 #include "OtherShips.hpp"
+#include "OtherShip.hpp"
 #include "RadarData.hpp"
 #include "Angles.hpp"
 #include "Constants.hpp"
@@ -784,7 +785,8 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
     //Some tuning constants
     irr::f32 radarFactorLand=2.0;
     irr::f32 radarFactorVessel=0.0001;
-    irr::f32 radarFactorRACON= radarFactorVessel * pow(1852.0/200.0, 2); // for Equivalent RCS of 1m2 at 200m(Fig 8.11, Target detection by marine radar)
+    irr::f32 radarFactorRACON = radarFactorVessel * pow(1852.0/200.0, 2); // for Equivalent RCS of 1m2 at 200m(Fig 8.11, Target detection by marine radar)
+    irr::f32 radarFactorSART = radarFactorRACON; //FIXME: simple version for now
 
     //Convert range to cell size
     irr::f32 cellLength = M_IN_NM*radarRangeNm.at(radarRangeIndex)/rangeResolution; ; //Assume that radarRangeIndex is in bounds
@@ -852,6 +854,21 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
 
             //Scan other contacts here
             for(unsigned int thisContact = 0; thisContact<radarData.size(); thisContact++) {
+                
+                // Extra check for SART contacts
+                if (radarData.at(thisContact).SART &&
+                    (radarData.at(thisContact).SARTtimeStamp > 0) &&
+                    (absoluteTime - radarData.at(thisContact).SARTtimeStamp <= 4)) 
+                {
+                    irr::f32 sartEchoStrength = radarFactorSART * std::pow(M_IN_NM / localRange, 2); //RACON / SART goes with inverse square law as we are receiving the direct signal, not echo
+                    
+                    irr::f32 relativeSARTAngle = currentScanAngle - radarData.at(thisContact).angle;
+                    if (fabs(relativeSARTAngle) < 10) {
+                        scanArray[currentScanLine][currentStep] += sartEchoStrength;
+                    }
+                    
+                }
+
                 irr::f32 contactHeightAboveLine = (radarData.at(thisContact).height - radarScannerHeight - dropWithCurvature) - scanSlope*localRange;
                 if (contactHeightAboveLine > 0) {
                     //Contact would be visible if in this cell. Check if it is
@@ -899,7 +916,7 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
                                         || (rangeAtCellMax >= minCellRange && rangeAtCellMax <= maxCellRange)
                                         || (rangeAtCellMin < minCellRange && rangeAtCellMax > maxCellRange)
                                         || (rangeAtCellMax < minCellRange && rangeAtCellMin > maxCellRange))) {
-
+                                
                                 irr::f32 radarEchoStrength = radarFactorVessel * std::pow(M_IN_NM/localRange,4) * radarData.at(thisContact).rcs;
                                 scanArray[currentScanLine][currentStep] += radarEchoStrength;
 
@@ -907,6 +924,17 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
                                     if (std::fmod(scenarioTime + radarData.at(thisContact).raconOffsetTime, 60.0f) <= radarData.at(thisContact).raconOnTime) {
                                         irr::f32 raconEchoStrength = radarFactorRACON * std::pow(M_IN_NM / localRange, 2); //RACON / SART goes with inverse square law as we are receiving the direct signal, not echo
                                         addRaconString(raconEchoStrength, cellLength, localRange, radarData.at(thisContact).racon);
+                                    }
+                                }
+
+                                // If SART on, and contact is detectable in noise
+                                if (radarData.at(thisContact).SART) {
+                                    if (radarEchoStrength*2 > localNoise) { 
+                                        // Check contact type before casting!
+                                        if (radarData.at(thisContact).contactType == otherShipContact) {
+                                            OtherShip* shipContact = static_cast<OtherShip*>(radarData.at(thisContact).contact);
+                                            shipContact->setSARTtimeStamp(absoluteTime);
+                                        }
                                     }
                                 }
 

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -858,15 +858,18 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
                 // Extra check for SART contacts
                 if (radarData.at(thisContact).SART &&
                     (radarData.at(thisContact).SARTtimeStamp > 0) &&
-                    (absoluteTime - radarData.at(thisContact).SARTtimeStamp <= 4)) 
+                    (absoluteTime - radarData.at(thisContact).SARTtimeStamp <= 4)) // TODO: Document or configure hardcoding here
                 {
-                    irr::f32 sartEchoStrength = radarFactorSART * std::pow(M_IN_NM / localRange, 2); //RACON / SART goes with inverse square law as we are receiving the direct signal, not echo
-                    
+                    // Relative angle in range -180 to 180 degrees
                     irr::f32 relativeSARTAngle = currentScanAngle - radarData.at(thisContact).angle;
-                    if (fabs(relativeSARTAngle) < 10) {
-                        scanArray[currentScanLine][currentStep] += sartEchoStrength;
+                    if (relativeSARTAngle > 180) {
+                        relativeSARTAngle -= 360;
                     }
-                    
+                    if (relativeSARTAngle < -180) {
+                        relativeSARTAngle += 360;
+                    }
+
+                    scanArray[currentScanLine][currentStep] += getSARTStrength(radarFactorSART, radarData.at(thisContact).range, localRange, relativeSARTAngle);
                 }
 
                 irr::f32 contactHeightAboveLine = (radarData.at(thisContact).height - radarScannerHeight - dropWithCurvature) - scanSlope*localRange;
@@ -1374,6 +1377,47 @@ void RadarCalculation::addRaconReturn(irr::f32 raconEchoStrength, irr::f32 cellL
 
     // Update raconEchoStart for the next character
     raconEchoStart = raconEchoEnd + raconSpaceLength;
+}
+
+irr::f32 RadarCalculation::getSARTStrength(irr::f32 radarFactorSART, irr::f32 sartRange, irr::f32 localRange, irr::f32 relativeSARTAngle) const
+{
+    irr::f32 relativeSARTRange = localRange - sartRange;
+    irr::f32 sartEchoStrength = radarFactorSART * std::pow(M_IN_NM / sartRange, 2); //RACON / SART goes with inverse square law as we are receiving the direct signal, not echo
+    
+    irr::f32 angleFactor;
+    irr::f32 minAngularWidth = fmax(scanAngleStep, 3.0f); // Ensure SART return beam isn't too narrow to see
+
+    if (fabs(relativeSARTAngle) <= minAngularWidth / 2.0) {
+        // In main beam
+        angleFactor = 1;
+    }
+    else {
+        // Sidelobe region. Initial simple version for testing
+        angleFactor = 0.001 * (180.0 - fabs(relativeSARTAngle)) / 180.0;
+    }
+
+    irr::f32 returnStrength = 0;
+    
+    // Main returns:
+    irr::f32 mainReturnStart = 0.3 * M_IN_NM; // Dependent on receiving radar tuning within SART sweep
+    irr::f32 mainReturnSpacing = 0.64 * M_IN_NM; // Set by SART sweep time
+    irr::f32 mainReturnLength = 0.1 * M_IN_NM; // Factor to account for how long SART pulse is within bandwidth;
+    int numberOfMainReturns = 12;
+    irr::f32 mainReturnEnd = mainReturnStart + mainReturnSpacing * (numberOfMainReturns - 1);
+
+    if ((relativeSARTRange >= mainReturnStart - 0.5 * mainReturnLength) && (relativeSARTRange <= mainReturnEnd + 0.5 * mainReturnLength)) {
+        for (int i = 0; i < numberOfMainReturns; i++) {
+            irr::f32 thisReturnDist = mainReturnStart + i * mainReturnSpacing;
+            irr::f32 thisReturnDistMin = thisReturnDist - mainReturnLength / 2;
+            irr::f32 thisReturnDistMax = thisReturnDistMin + mainReturnLength;
+
+            if ((relativeSARTRange >= thisReturnDistMin) && (relativeSARTRange <= thisReturnDistMax)) {
+                returnStrength += angleFactor * sartEchoStrength;
+            }
+        }
+    }
+    
+    return returnStrength;
 }
 
 void RadarCalculation::addManualPoint(bool newContact, irr::core::vector3d<int64_t> offsetPosition, const OwnShip& ownShip, uint64_t absoluteTime)

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -924,7 +924,7 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
                                         || (rangeAtCellMax >= minCellRange && rangeAtCellMax <= maxCellRange)
                                         || (rangeAtCellMin < minCellRange && rangeAtCellMax > maxCellRange)
                                         || (rangeAtCellMax < minCellRange && rangeAtCellMin > maxCellRange))) {
-                                
+
                                 irr::f32 radarEchoStrength = radarFactorVessel * std::pow(M_IN_NM/localRange,4) * radarData.at(thisContact).rcs;
                                 scanArray[currentScanLine][currentStep] += radarEchoStrength;
 
@@ -1389,15 +1389,13 @@ irr::f32 RadarCalculation::getSARTStrength(irr::f32 radarFactorSART, irr::f32 sa
     irr::f32 relativeSARTRange = localRange - sartRange;
     irr::f32 sartEchoStrength = radarFactorSART * std::pow(M_IN_NM / sartRange, 2); //RACON / SART goes with inverse square law as we are receiving the direct signal, not echo
     
-    irr::f32 angleFactor;
-    irr::f32 minAngularWidth = fmax(scanAngleStep, 3.0f); // Ensure SART return beam isn't too narrow to see
-
     // radar sidelobes, following 'Target detection by marine radar', section 2.8.1
     irr::f32 widthFactor = 3.0;
     irr::f32 waveLength = 0.1;
     irr::f32 relativeAngleRadians = relativeSARTAngle * irr::core::DEGTORAD;
 
     irr::f32 intermediateCalculation = widthFactor * relativeAngleRadians / waveLength;
+    irr::f32 angleFactor;
     if (intermediateCalculation != 0) {
         angleFactor = pow(sin(intermediateCalculation) / intermediateCalculation, 2);
     } else {

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -786,7 +786,7 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
     irr::f32 radarFactorLand=2.0;
     irr::f32 radarFactorVessel=0.0001;
     irr::f32 radarFactorRACON = radarFactorVessel * pow(1852.0/200.0, 2); // for Equivalent RCS of 1m2 at 200m(Fig 8.11, Target detection by marine radar)
-    irr::f32 radarFactorSART = radarFactorRACON; //FIXME: simple version for now
+    irr::f32 radarFactorSART = radarFactorRACON * 0.1; // Like RACON, but lower strength;
 
     //Convert range to cell size
     irr::f32 cellLength = M_IN_NM*radarRangeNm.at(radarRangeIndex)/rangeResolution; ; //Assume that radarRangeIndex is in bounds
@@ -1387,13 +1387,16 @@ irr::f32 RadarCalculation::getSARTStrength(irr::f32 radarFactorSART, irr::f32 sa
     irr::f32 angleFactor;
     irr::f32 minAngularWidth = fmax(scanAngleStep, 3.0f); // Ensure SART return beam isn't too narrow to see
 
-    if (fabs(relativeSARTAngle) <= minAngularWidth / 2.0) {
-        // In main beam
+    // radar sidelobes, following 'Target detection by marine radar', section 2.8.1
+    irr::f32 widthFactor = 3.0;
+    irr::f32 waveLength = 0.1;
+    irr::f32 relativeAngleRadians = relativeSARTAngle * irr::core::DEGTORAD;
+
+    irr::f32 intermediateCalculation = widthFactor * relativeAngleRadians / waveLength;
+    if (intermediateCalculation != 0) {
+        angleFactor = pow(sin(intermediateCalculation) / intermediateCalculation, 2);
+    } else {
         angleFactor = 1;
-    }
-    else {
-        // Sidelobe region. Initial simple version for testing
-        angleFactor = 0.001 * (180.0 - fabs(relativeSARTAngle)) / 180.0;
     }
 
     irr::f32 returnStrength = 0;

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -855,10 +855,14 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
             //Scan other contacts here
             for(unsigned int thisContact = 0; thisContact<radarData.size(); thisContact++) {
                 
+                // By default, 3s, but may need to be longer with high time acceleration)
+                // 30 here is max number of scans per loop
+                uint64_t maxTimeForSARTDetected = std::max(3, int(2 * deltaTime * 360 / (30 * scanAngleStep)));
+                
                 // Extra check for SART contacts
                 if (radarData.at(thisContact).SART &&
                     (radarData.at(thisContact).SARTtimeStamp > 0) &&
-                    (absoluteTime - radarData.at(thisContact).SARTtimeStamp <= 4)) // TODO: Document or configure hardcoding here
+                    (absoluteTime - radarData.at(thisContact).SARTtimeStamp <= maxTimeForSARTDetected)) 
                 {
                     // Relative angle in range -180 to 180 degrees
                     irr::f32 relativeSARTAngle = currentScanAngle - radarData.at(thisContact).angle;

--- a/src/RadarCalculation.cpp
+++ b/src/RadarCalculation.cpp
@@ -807,6 +807,11 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
     irr::u32 scansPerLoop = RADAR_RPM * RPMtoDEGPERSECOND * deltaTime / (irr::f32) scanAngleStep + (irr::f32) rand() / RAND_MAX ; //Add random value (0-1, mean 0.5), so with rounding, we get the correct radar speed, even though we can only do an integer number of scans
 
     if (scansPerLoop > 30) {scansPerLoop = 30;} //Limit to reasonable bounds
+
+    // By default show SART returns if scanned within 3s, but may need to be longer with high time acceleration)
+    // 30 here is max number of scans per loop
+    uint64_t maxTimeForSARTDetected = std::max(3, int(2 * deltaTime * 360 / (30 * scanAngleStep)));
+
     for(irr::u32 i = 0; i<scansPerLoop;i++) { //Start of repeatable scan section
 
         // the actual angle we want to work with has to be determined here
@@ -854,10 +859,6 @@ void RadarCalculation::scan(irr::core::vector3d<int64_t> offsetPosition, const T
 
             //Scan other contacts here
             for(unsigned int thisContact = 0; thisContact<radarData.size(); thisContact++) {
-                
-                // By default, 3s, but may need to be longer with high time acceleration)
-                // 30 here is max number of scans per loop
-                uint64_t maxTimeForSARTDetected = std::max(3, int(2 * deltaTime * 360 / (30 * scanAngleStep)));
                 
                 // Extra check for SART contacts
                 if (radarData.at(thisContact).SART &&

--- a/src/RadarCalculation.hpp
+++ b/src/RadarCalculation.hpp
@@ -233,6 +233,7 @@ class RadarCalculation
         void scan(irr::core::vector3d<int64_t> offsetPosition, const Terrain& terrain, const OwnShip& ownShip, const Buoys& buoys, const OtherShips& otherShips, irr::f32 weather, irr::f32 rain, irr::f32 tideHeight, irr::f32 deltaTime, uint64_t absoluteTime, irr::f32 scenarioTime);
         void addRaconString(irr::f32 raconEchoStrength, irr::f32 cellLength, irr::f32 contactRange, std::string raconCode);
         void addRaconReturn(irr::f32 raconEchoStrength, irr::f32 cellLength, irr::f32 raconEchoLength, irr::f32 raconSpaceLength, irr::f32& raconEchoStart);
+        irr::f32 getSARTStrength(irr::f32 radarFactorSART, irr::f32 sartRange, irr::f32 localRange, irr::f32 relativeSARTAngle) const;
         void updateARPA(irr::core::vector3d<int64_t> offsetPosition, const OwnShip& ownShip, uint64_t absoluteTime);
         void updateArpaEstimate(ARPAContact& thisArpaContact, int contactID, const OwnShip& ownShip, irr::core::vector3d<int64_t> absolutePosition, uint64_t absoluteTime);
         irr::f32 radarNoise(irr::f32 radarNoiseLevel, irr::f32 radarSeaClutter, irr::f32 radarRainClutter, irr::f32 weather, irr::f32 radarRange,irr::f32 radarBrgDeg, irr::f32 windDirectionDeg, irr::f32 radarInclinationAngle, irr::f32 rainIntensity);

--- a/src/RadarData.hpp
+++ b/src/RadarData.hpp
@@ -21,6 +21,8 @@
 
 #include <string>
 
+enum ContactType {buoyContact, otherShipContact, unknownContact};
+
 struct RadarData {
 
     irr::f32 height;
@@ -38,12 +40,14 @@ struct RadarData {
     irr::f32 rcs;
     irr::f32 solidHeight;
     void* contact;
+    ContactType contactType;
 
     bool hidden;
     std::string racon; //Racon code if set
     irr::f32 raconOnTime; //Duration on per minute, in seconds
     irr::f32 raconOffsetTime; // Offset in seconds
     bool SART; //SART enabled?
+    uint64_t SARTtimeStamp; // SART last detected at this time
     //irr::f32 radarHorizon; //Only used for tracking contacts outside current radar visibility range
 
     //Default constructor - initialise to zero
@@ -67,7 +71,9 @@ struct RadarData {
         racon(""),
         raconOffsetTime(0),
         raconOnTime(0),
-        SART(false)
+        SART(false),
+        SARTtimeStamp(0),
+        contactType(unknownContact)
         {}
 
 };

--- a/src/RadarData.hpp
+++ b/src/RadarData.hpp
@@ -20,6 +20,7 @@
 #include "irrlicht.h"
 
 #include <string>
+#include <cstdint> //for uint64_t
 
 enum ContactType {buoyContact, otherShipContact, unknownContact};
 

--- a/src/ScenarioDataStructure.cpp
+++ b/src/ScenarioDataStructure.cpp
@@ -74,6 +74,8 @@ std::string OtherShipData::serialise(bool withSpaces)
     }
     serialised.append(separator);
     serialised.append(Utilities::lexical_cast<std::string>(drifting));
+    serialised.append(separator);
+    serialised.append(Utilities::lexical_cast<std::string>(SART));
     return serialised;
 }
 
@@ -94,9 +96,13 @@ void OtherShipData::deserialise(std::string data)
             legs.push_back(tempLeg);
         }
     }
-    if (splitData.size() == 6) {
-        // Additional drifting entry (SCN4 only)
+    if (splitData.size() > 5) {
+        // Additional drifting entry (SCN4 & SCN5 only)
         drifting = Utilities::lexical_cast<bool>(splitData.at(5));
+    }
+    if (splitData.size() > 6) {
+        // Additional drifting entry (SCN5 only)
+        SART = Utilities::lexical_cast<bool>(splitData.at(6));
     }
 
 }
@@ -141,7 +147,8 @@ std::string ScenarioData::serialise(bool withSpaces)
     // SCN2 is the same as SCN1, but allows whitespace around the delimiters
     // SCN3 adds wind and tidal override information
     // SCN4 adds other ship drifting flag
-    std::string serialised = "SCN4"; //Scenario data, serialised format 3
+    // SCN5 adds other ship SART flag
+    std::string serialised = "SCN5"; //Scenario data, serialised format
     serialised.append(separator);
     serialised.append(scenarioName);
     serialised.append(separator);
@@ -215,9 +222,10 @@ void ScenarioData::deserialise(std::string data)
             dataPopulated = true; // Currently only used in scenario editor
         }
     } else if (splitData.size() == 16) {
-        if ((splitData.at(0) == "SCN3") || (splitData.at(0) == "SCN4")) {
+        if ((splitData.at(0) == "SCN3") || (splitData.at(0) == "SCN4") || (splitData.at(0) == "SCN5")) {
             // SCN3 allows for tidal information to be overridden from scenario
             // SCN4 adds drifting flag in other ship data
+            // SCN5 adds SART flag in other ship data
             scenarioName = splitData.at(1);
             worldName = splitData.at(2);
             startTime = Utilities::lexical_cast<irr::f32>(splitData.at(3));

--- a/src/ScenarioDataStructure.hpp
+++ b/src/ScenarioDataStructure.hpp
@@ -54,8 +54,9 @@ class OtherShipData {
     irr::f32 initialX, initialZ; // initialX and initialZ only used for scenario editor
     std::vector<LegData> legs;
     bool drifting; // If ship should move with wind and tidal stream
+    bool SART;
 
-    OtherShipData():initialLong(0), initialLat(0), initialX(0), initialZ(0), drifting(false){}
+    OtherShipData(): mmsi(0), initialLong(0), initialLat(0), initialX(0), initialZ(0), drifting(false), SART(false){}
 
     std::string serialise(bool withSpaces);
     void deserialise(std::string data);

--- a/src/SimulationModel.cpp
+++ b/src/SimulationModel.cpp
@@ -412,6 +412,16 @@ SimulationModel::~SimulationModel()
         return otherShips.getMMSI(number);
     }
 
+    bool SimulationModel::getOtherShipSARTOn(int number) const
+    {
+        return otherShips.getSARTOn(number);
+    }
+
+    void SimulationModel::setOtherShipSARTOn(int number, bool sartState)
+    {
+        otherShips.setSARTOn(number, sartState);
+    }
+
     void SimulationModel::setOtherShipMMSI(int number, irr::u32 mmsi) {
         otherShips.setMMSI(number,mmsi);
     }

--- a/src/SimulationModel.hpp
+++ b/src/SimulationModel.hpp
@@ -192,6 +192,8 @@ public:
     irr::f32 getOtherShipHeading(int number) const;
     irr::f32 getOtherShipSpeed(int number) const; //Speed in m/s
     irr::u32 getOtherShipMMSI(int number) const;
+    bool getOtherShipSARTOn(int number) const;
+    void setOtherShipSARTOn(int number, bool sartState);
     void setOtherShipHeading(int number, irr::f32 hdg);
     void setOtherShipPos(int number, irr::f32 positionX, irr::f32 positionZ);
     void setOtherShipRateOfTurn(int number, irr::f32 rateOfTurn);

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -388,11 +388,21 @@ namespace Utilities
             thisOtherShip.mmsi    = IniFile::iniFileTou32(scenarioOtherShipsFilename,IniFile::enumerate1("MMSI",i));
             thisOtherShip.initialLong = IniFile::iniFileTof32(scenarioOtherShipsFilename,IniFile::enumerate1("InitLong",i));
             thisOtherShip.initialLat  = IniFile::iniFileTof32(scenarioOtherShipsFilename,IniFile::enumerate1("InitLat",i));
+            
+            // Drifting:
             if (IniFile::iniFileTou32(scenarioOtherShipsFilename, IniFile::enumerate1("Drifting", i)) == 1) {
                 thisOtherShip.drifting = true;
             }
             else {
                 thisOtherShip.drifting = false;
+            }
+
+            // SART
+            if (IniFile::iniFileTou32(scenarioOtherShipsFilename, IniFile::enumerate1("SART", i)) == 1) {
+                thisOtherShip.SART = true;
+            }
+            else {
+                thisOtherShip.SART = false;
             }
 
             irr::u32 numberOfLegs = IniFile::iniFileTou32(scenarioOtherShipsFilename,IniFile::enumerate1("Legs",i));

--- a/src/controller/EventReceiver.cpp
+++ b/src/controller/EventReceiver.cpp
@@ -254,6 +254,26 @@
                     network->setStringToSend(messageToSend);
                 }
             }
+
+            if (event.GUIEvent.EventType == irr::gui::EGET_CHECKBOX_CHANGED) {
+                if (id == GUIMain::GUI_ID_SART_CHECKBOX) {
+                    int ship = gui->getSelectedShip();
+                    if (ship > 0) {
+                        // Other ship
+                        std::string messageToSend = "MCSR,";
+                        messageToSend.append(Utilities::lexical_cast<std::string>(ship));
+                        messageToSend.append(",");
+                        if (((irr::gui::IGUICheckBox*)event.GUIEvent.Caller)->isChecked()) {
+                            messageToSend.append("1");
+                        } else {
+                            messageToSend.append("0");
+                        }
+                        messageToSend.append("#");
+                        network->setStringToSend(messageToSend);
+                    }
+                }
+            }
+            
             /*
             if (event.GUIEvent.EventType==irr::gui::EGDT_WINDOW_CLOSE) {
                 if (id==GUIMain::GUI_ID_WINDOW) {

--- a/src/controller/GUI.cpp
+++ b/src/controller/GUI.cpp
@@ -70,6 +70,9 @@ GUIMain::GUIMain(irr::IrrlichtDevice* device, Lang* language)
     mmsiEdit = guienv->addEditBox(L"",irr::core::rect<irr::s32>(1*fw,7.5*fh,12*fw,8.5*fh),false,mainTab,GUI_ID_MMSI_EDITBOX);
     setMMSI = guienv->addButton(irr::core::rect<irr::s32>(1*fw,8.5*fh,12*fw,9.5*fh),mainTab,GUI_ID_SETMMSI_BUTTON,language->translate("setMMSI").c_str());
 
+    //Add SART setting
+    sartEnable = guienv->addCheckBox(false, irr::core::rect<irr::s32>(25 * fw, 7.5 * fh, 28 * fw, 8.5 * fh), mainTab, GUI_ID_SART_CHECKBOX);
+
     //Add leg selector drop down
     legSelector  = guienv->addListBox(irr::core::rect<irr::s32>(12.5*fw,6*fh,24*fw,9.5*fh),mainTab,GUI_ID_LEG_LISTBOX);
     legSelectorTitle = guienv->addStaticText(language->translate("selectLeg").c_str(),irr::core::rect<irr::s32>(12.5*fw,4.5*fh,24*fw,5.5*fh),false,false,mainTab);
@@ -285,6 +288,11 @@ void GUIMain::updateGuiData(irr::f32 time, irr::s32 mapOffsetX, irr::s32 mapOffs
     if (editBoxesNeedUpdating) {
         if (selectedShip >= 0 && selectedShip < otherShips.size()) {
             mmsiEdit->setText(irr::core::stringw(otherShips.at(selectedShip).mmsi).c_str());
+            sartEnable->setEnabled(true);
+            sartEnable->setChecked(otherShips.at(selectedShip).SART);
+        } else {
+            sartEnable->setChecked(false);
+            sartEnable->setEnabled(false);
         }
         if (selectedShip >= 0 && selectedShip < otherShips.size() && selectedLeg >= 0 && selectedLeg < otherShips.at(selectedShip).legs.size()) {
             legCourseEdit  ->setText(irr::core::stringw(otherShips.at(selectedShip).legs.at(selectedLeg).bearing).c_str());

--- a/src/controller/GUI.cpp
+++ b/src/controller/GUI.cpp
@@ -395,6 +395,11 @@ void GUIMain::drawInformationOnMap(const irr::f32& time, const irr::s32& mapOffs
         //number
         int thisShipNumber = 1 + it - otherShips.begin();
         irr::core::stringw displayNumber = irr::core::stringw(thisShipNumber);
+        
+        if (it->SART) {
+            displayNumber.append(L" SART ");
+        }
+        
         if (it->mmsi != 0) {
             displayNumber.append(L" (MMSI:");
             displayNumber.append(irr::core::stringw(it->mmsi));

--- a/src/controller/GUI.cpp
+++ b/src/controller/GUI.cpp
@@ -72,6 +72,7 @@ GUIMain::GUIMain(irr::IrrlichtDevice* device, Lang* language)
 
     //Add SART setting
     sartEnable = guienv->addCheckBox(false, irr::core::rect<irr::s32>(25 * fw, 7.5 * fh, 28 * fw, 8.5 * fh), mainTab, GUI_ID_SART_CHECKBOX);
+    guienv->addStaticText(language->translate("SART").c_str(), irr::core::rect<irr::s32>(25 * fw, 6 * fh, 35 * fw, 7 * fh), false, false, mainTab);
 
     //Add leg selector drop down
     legSelector  = guienv->addListBox(irr::core::rect<irr::s32>(12.5*fw,6*fh,24*fw,9.5*fh),mainTab,GUI_ID_LEG_LISTBOX);

--- a/src/controller/GUI.hpp
+++ b/src/controller/GUI.hpp
@@ -40,6 +40,7 @@ public:
         GUI_ID_SHIP_COMBOBOX,
         GUI_ID_LEG_LISTBOX,
         GUI_ID_MMSI_EDITBOX,
+        GUI_ID_SART_CHECKBOX,
         GUI_ID_COURSE_EDITBOX,
         GUI_ID_SPEED_EDITBOX,
         GUI_ID_DISTANCE_EDITBOX,
@@ -110,6 +111,7 @@ private:
     irr::gui::IGUIEditBox* legSpeedEdit;
     irr::gui::IGUIEditBox* legDistanceEdit;
     irr::gui::IGUIEditBox* mmsiEdit;
+    irr::gui::IGUICheckBox* sartEnable;
     irr::gui::IGUIButton* changeLeg;
     irr::gui::IGUIButton* changeLegCourseSpeed;
     irr::gui::IGUIButton* addLeg;

--- a/src/controller/Network.cpp
+++ b/src/controller/Network.cpp
@@ -317,7 +317,15 @@ void Network::findOtherShipData(const std::vector<std::string>& otherShipsDataSt
             otherShipsData.at(i).X=Utilities::lexical_cast<irr::f32>(thisShipData.at(0));
             otherShipsData.at(i).Z=Utilities::lexical_cast<irr::f32>(thisShipData.at(1));
             otherShipsData.at(i).mmsi =Utilities::lexical_cast<irr::u32>(thisShipData.at(6));
-            //Todo: use SART etc
+            
+            // SART
+            if (thisShipData.at(5) == "1") {
+                otherShipsData.at(i).SART = true;
+            } else {
+                otherShipsData.at(i).SART = false;
+            }
+
+            // Leg data
             irr::u32 numberOfLegs = Utilities::lexical_cast<irr::u32>(thisShipData.at(7));
             std::vector<std::string> legsDataString = Utilities::split(thisShipData.at(8),'/');
             if (numberOfLegs == legsDataString.size()) {

--- a/src/controller/Network.cpp
+++ b/src/controller/Network.cpp
@@ -101,7 +101,8 @@ std::string Network::findWorldName()
                 if ((receivedString.substr(0,4) == "SCN1") || 
                     (receivedString.substr(0,4) == "SCN2") || 
                     (receivedString.substr(0,4) == "SCN3") ||
-                    (receivedString.substr(0,4) == "SCN4")) { //Check if it starts with SCN1-SCN4
+                    (receivedString.substr(0,4) == "SCN4") ||
+                    (receivedString.substr(0,4) == "SCN5")) { //Check if it starts with SCN1-SCN5
 
                     //Find world model from this
                     std::vector<std::string> receivedData = Utilities::split(receivedString,'#');

--- a/src/controller/OtherShipDataStruct.hpp
+++ b/src/controller/OtherShipDataStruct.hpp
@@ -27,6 +27,7 @@ struct OtherShipDisplayData : public ShipData //To hold information about a ship
 {
     std::vector<Leg> legs;
     irr::u32 mmsi;
+    bool SART;
 };
 
 #endif // __OWNSHIPDATASTRUCT_HPP_INCLUDED__

--- a/src/editor/ControllerModel.cpp
+++ b/src/editor/ControllerModel.cpp
@@ -484,6 +484,17 @@ void ControllerModel::setDrifting(irr::s32 ship, bool drifting)
     }
 }
 
+void ControllerModel::setSARTOn(irr::s32 ship, bool SART)
+{
+    //If other ship:
+    if (ship > 0) {
+        int otherShipIndex = ship - 1;
+        if (otherShipIndex < scenarioData->otherShipsData.size()) {
+            scenarioData->otherShipsData.at(otherShipIndex).SART = SART;
+        }
+    }
+}
+
 void ControllerModel::addLeg(irr::s32 ship, irr::s32 afterLegNumber, irr::f32 legCourse, irr::f32 legSpeed, irr::f32 legDistance)
 {
     //If other ship:
@@ -656,6 +667,9 @@ void ControllerModel::save()
         otherFile << "mmsi(" << i << ")=" << scenarioData->otherShipsData.at(i-1).mmsi << std::endl;
         if (scenarioData->otherShipsData.at(i - 1).drifting) {
             otherFile << "Drifting(" << i << ")=1" << std::endl;
+        }
+        if (scenarioData->otherShipsData.at(i - 1).SART) {
+            otherFile << "SART(" << i << ")=1" << std::endl;
         }
         //Don't save last leg, as this is an automatically added 'stop' leg.
         otherFile << "Legs(" << i << ")=" << scenarioData->otherShipsData.at(i-1).legs.size() - 1 << std::endl;

--- a/src/editor/ControllerModel.hpp
+++ b/src/editor/ControllerModel.hpp
@@ -55,6 +55,7 @@ public:
     void addLeg(irr::s32 ship, irr::s32 afterLegNumber, irr::f32 legCourse, irr::f32 legSpeed, irr::f32 legDistance);
     void setMMSI(irr::s32 ship, int mmsi);
     void setDrifting(irr::s32 ship, bool drifting);
+    void setSARTOn(irr::s32 ship, bool SART);
     void addShip(std::string name, irr::core::vector2df position);
 	void deleteShip(irr::s32 ship);
     void recalculateLegTimes();

--- a/src/editor/EventReceiver.cpp
+++ b/src/editor/EventReceiver.cpp
@@ -140,6 +140,11 @@
                         model->setDrifting(gui->getSelectedShip(), ((irr::gui::IGUICheckBox*)event.GUIEvent.Caller)->isChecked());
                     }
                 }
+                if (id == GUIMain::GUI_ID_SART_CHECKBOX) {
+                    if (gui->getSelectedShip() > 0) {
+                        model->setSARTOn(gui->getSelectedShip(), ((irr::gui::IGUICheckBox*)event.GUIEvent.Caller)->isChecked());
+                    }
+                }
             }
 
             if (event.GUIEvent.EventType==irr::gui::EGET_COMBO_BOX_CHANGED || event.GUIEvent.EventType==irr::gui::EGET_LISTBOX_CHANGED) {

--- a/src/editor/GUI.cpp
+++ b/src/editor/GUI.cpp
@@ -84,17 +84,21 @@ GUIMain::GUIMain(irr::IrrlichtDevice* device, Lang* language, std::vector<std::s
     legSpeedEdit    = guienv->addEditBox(L"S",irr::core::rect<irr::s32>(0.18*su,0.24*sh,0.30*su,0.27*sh),false,shipTab,GUI_ID_SPEED_EDITBOX);
     legDistanceEdit = guienv->addEditBox(L"D",irr::core::rect<irr::s32>(0.35*su,0.24*sh,0.45*su,0.27*sh),false,shipTab,GUI_ID_DISTANCE_EDITBOX);
 
-    guienv->addStaticText(language->translate("setCourse").c_str(),irr::core::rect<irr::s32>(0.01*su,0.20*sh,0.13*su,0.23*sh),false,false,shipTab);
-    guienv->addStaticText(language->translate("setSpeed").c_str(),irr::core::rect<irr::s32>(0.18*su,0.20*sh,0.30*su,0.23*sh),false,false,shipTab);
-    guienv->addStaticText(language->translate("setDistance").c_str(),irr::core::rect<irr::s32>(0.35*su,0.20*sh,0.45*su,0.23*sh),false,false,shipTab);
+    guienv->addStaticText(language->translate("setCourse").c_str(),irr::core::rect<irr::s32>(0.01*su,0.22*sh,0.13*su,0.24*sh),false,false,shipTab);
+    guienv->addStaticText(language->translate("setSpeed").c_str(),irr::core::rect<irr::s32>(0.18*su,0.22*sh,0.30*su,0.24*sh),false,false,shipTab);
+    guienv->addStaticText(language->translate("setDistance").c_str(),irr::core::rect<irr::s32>(0.35*su,0.22*sh,0.45*su,0.24*sh),false,false,shipTab);
 
     //Add MMSI editing
     mmsiEdit = guienv->addEditBox(L"",irr::core::rect<irr::s32>(0.18*su,0.09*sh,0.31*su,0.12*sh),false,shipTab,GUI_ID_MMSI_EDITBOX);
-    setMMSI = guienv->addButton(irr::core::rect<irr::s32>(0.18*su,0.13*sh,0.31*su,0.16*sh),shipTab,GUI_ID_SETMMSI_BUTTON,language->translate("setMMSI").c_str());
+    setMMSI = guienv->addButton(irr::core::rect<irr::s32>(0.18*su,0.125*sh,0.31*su,0.155*sh),shipTab,GUI_ID_SETMMSI_BUTTON,language->translate("setMMSI").c_str());
 
     // Set if the ship can drift with wind and current
-    isDrifting = guienv->addCheckBox(false, irr::core::rect<irr::s32>(0.18*su,0.16*sh,0.20*su,0.19*sh), shipTab, GUI_ID_DRIFTING_CHECKBOX);
-    guienv->addStaticText(language->translate("allowDrifting").c_str(), irr::core::rect<irr::s32>(0.20 * su, 0.16 * sh, 0.31 * su, 0.19 * sh),false, false, shipTab);
+    isDrifting = guienv->addCheckBox(false, irr::core::rect<irr::s32>(0.18*su,0.155*sh,0.20*su,0.185*sh), shipTab, GUI_ID_DRIFTING_CHECKBOX);
+    guienv->addStaticText(language->translate("allowDrifting").c_str(), irr::core::rect<irr::s32>(0.20 * su, 0.155 * sh, 0.31 * su, 0.185 * sh),false, false, shipTab);
+
+    // Set if ship has SART activated
+    isSARTOn = guienv->addCheckBox(false, irr::core::rect<irr::s32>(0.18 * su, 0.19 * sh, 0.20 * su, 0.22 * sh), shipTab, GUI_ID_SART_CHECKBOX);
+    guienv->addStaticText(language->translate("SART").c_str(), irr::core::rect<irr::s32>(0.20 * su, 0.19 * sh, 0.31 * su, 0.22 * sh), false, false, shipTab);
 
     //Add buttons
     changeLeg       = guienv->addButton(irr::core::rect<irr::s32>(0.03*su, 0.28*sh, 0.23*su, 0.31*sh),shipTab,GUI_ID_CHANGE_BUTTON,language->translate("changeLeg").c_str());
@@ -413,10 +417,14 @@ void GUIMain::updateGuiData(ScenarioData scenarioData, irr::s32 mapOffsetX, irr:
             mmsiEdit->setText(irr::core::stringw(scenarioData.otherShipsData.at(selectedShip).mmsi).c_str());
             isDrifting->setEnabled(true);
             isDrifting->setChecked(scenarioData.otherShipsData.at(selectedShip).drifting);
+            isSARTOn->setEnabled(true);
+            isSARTOn->setChecked(scenarioData.otherShipsData.at(selectedShip).SART);
         } else if (selectedShip == -1) {
             mmsiEdit->setText(L"-");
             isDrifting->setEnabled(false);
             isDrifting->setChecked(false);
+            isSARTOn->setEnabled(false);
+            isSARTOn->setChecked(false);
         }
         if (selectedShip >= 0 && selectedShip < scenarioData.otherShipsData.size() && selectedLeg >= 0 && selectedLeg < scenarioData.otherShipsData.at(selectedShip).legs.size()) {
             legCourseEdit  ->setText(irr::core::stringw(scenarioData.otherShipsData.at(selectedShip).legs.at(selectedLeg).bearing).c_str());

--- a/src/editor/GUI.hpp
+++ b/src/editor/GUI.hpp
@@ -67,7 +67,8 @@ public:
         GUI_ID_OTHERSHIPSELECT_COMBOBOX,
         GUI_ID_WINDDIRECTION_EDITBOX,
         GUI_ID_WINDSPEED_EDITBOX,
-        GUI_ID_DRIFTING_CHECKBOX
+        GUI_ID_DRIFTING_CHECKBOX,
+        GUI_ID_SART_CHECKBOX
     };
 
     void updateGuiData(ScenarioData scenarioInfo, irr::s32 mapOffsetX, irr::s32 mapOffsetZ, irr::f32 metresPerPx, const std::vector<PositionData>& buoys, const std::vector<PositionData>& landObjects, irr::video::ITexture* displayMapTexture, irr::s32 selectedShip, irr::s32 selectedLeg, irr::f32 terrainLong, irr::f32 terrainLongExtent, irr::f32 terrainXWidth, irr::f32 terrainLat, irr::f32 terrainLatExtent, irr::f32 terrainZWidth);
@@ -129,6 +130,7 @@ private:
     irr::gui::IGUIButton* setMMSI;
 
     irr::gui::IGUICheckBox* isDrifting;
+    irr::gui::IGUICheckBox* isSARTOn;
 
     irr::gui::IGUIComboBox* ownShipTypeSelector;
     irr::gui::IGUIComboBox* otherShipTypeSelector;

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -584,6 +584,13 @@ int main (int argc, char ** argv)
                 else {
                     thisShip.drifting = false;
                 }
+
+                if (IniFile::iniFileTou32(otherShipIniFilename, IniFile::enumerate1("SART", i)) == 1) {
+                    thisShip.SART = true;
+                }
+                else {
+                    thisShip.SART = false;
+                }
                 
                 int numberOfLegs = IniFile::iniFileTof32(otherShipIniFilename,IniFile::enumerate1("Legs",i));
 

--- a/src/multiplayerHub/main.cpp
+++ b/src/multiplayerHub/main.cpp
@@ -393,7 +393,7 @@ int main()
 
             //3: Info on each other ship
             //For each Other, terminated with '#' at end of list
-            //    PosX,PosZ,Heading,speed (kts),0(SART), 0 (Number of legs, 0 as we don't need leg info in multiplayer)|
+            //    PosX,PosZ,Heading,speed (kts),rate of turn,0(SART, assumed off), 0 (Number of legs, 0 as we don't need leg info in multiplayer)|
             std::string otherShipsString;
             for(unsigned int i = 0; i < (numberOfOtherShips+1); i++) {
                 if (i!=thisPeer) {
@@ -470,7 +470,7 @@ int main()
             (2) Number other, number buoys, number MOB (0)#
 
             (3) For each Other, terminated with '#' at end of list
-                PosX,PosZ,Heading,speed (kts),0(SART), 0 (Number of legs, 0 as we don't need leg info in multiplayer)|
+                PosX,PosZ,Heading,speed (kts),rate of turn,0(SART), 0 (Number of legs, 0 as we don't need leg info in multiplayer)|
 
             Records 4 to 10 not used (separate with '#')
 


### PR DESCRIPTION
Allow SART contacts to be included, defined for each own ship in the scenario, and can be enabled/disabled from the map controller.