### PR TITLE
Update CMakeLists to work with MSVC on Windows.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": "Bridge Command",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-bc.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Scenario Editor",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-ed.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Settings Editor",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-ini.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Map Controller",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-mc.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Multiplayer Hub",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-mh.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Repeater",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand-rp.exe",
+            "cwd": "${workspaceFolder}/bin"
+        },
+        {
+            "name": "Launcher",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/BridgeCommand.exe",
+            "cwd": "${workspaceFolder}/bin"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,49 +3,49 @@
     "configurations": [
         
         {
-            "name": "Bridge Command",
+            "name": "Bridge Command (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-bc.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Scenario Editor",
+            "name": "Scenario Editor (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-ed.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Settings Editor",
+            "name": "Settings Editor (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-ini.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Map Controller",
+            "name": "Map Controller (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-mc.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Multiplayer Hub",
+            "name": "Multiplayer Hub (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-mh.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Repeater",
+            "name": "Repeater (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand-rp.exe",
             "cwd": "${workspaceFolder}/bin"
         },
         {
-            "name": "Launcher",
+            "name": "Launcher (vsdbg)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/BridgeCommand.exe",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "${workspaceFolder}/src"
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ LINK_DIRECTORIES(libs/portaudio/lib)
 LINK_DIRECTORIES(libs/enet-1.3.14)
 LINK_DIRECTORIES(libs/Irrlicht/irrlicht-svn/lib/Win64-visualstudio)
 LINK_DIRECTORIES(libs/OpenXR/OpenXR-SDK-main/build/win64/src/loader/Release)
+LINK_DIRECTORIES(libs/OpenXR/OpenXR-SDK-main/build/win64/src/loader/Debug)
 else (WIN32)
 add_subdirectory(libs/asio)
 add_subdirectory(libs/enet-1.3.14)
@@ -158,7 +159,8 @@ elseif (WIN32)
         portaudio_x64
         winmm
         ws2_32
-        openxr_loader
+        debug openxr_loaderd
+        optimized openxr_loader
         opengl32
     )
 else ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,12 +14,32 @@ if (APPLE)
     set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 endif (APPLE)
 
-add_subdirectory(libs/asio)
-add_subdirectory(libs/enet-1.3.14)
-add_subdirectory(libs/Irrlicht)
-add_subdirectory(libs/serial)
+if (WIN32)
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif (WIN32)
 
+add_subdirectory(libs/asio)
+add_subdirectory(libs/serial)
 include_directories("libs/enet-1.3.14/include")
+
+if (WIN32)
+include_directories(libs/libsndfile/include)
+include_directories(libs/portaudio/include)
+include_directories(libs/Irrlicht/irrlicht-svn/include)
+include_directories(libs/OpenXR/OpenXR-SDK-main/include/openxr)
+
+LINK_DIRECTORIES(libs/libsndfile/lib)
+LINK_DIRECTORIES(libs/portaudio/lib)
+LINK_DIRECTORIES(libs/enet-1.3.14)
+LINK_DIRECTORIES(libs/Irrlicht/irrlicht-svn/lib/Win64-visualstudio)
+LINK_DIRECTORIES(libs/OpenXR/OpenXR-SDK-main/build/win64/src/loader/Release)
+else (WIN32)
+add_subdirectory(libs/enet-1.3.14)
+#add_subdirectory(libs/Irrlicht)
+add_subdirectory(libs/OpenXR/OpenXR-SDK-main)
+endif (WIN32)
+
 add_definitions(-DWITH_SOUND)
 # add_definitions(-DWITH_PROFILING)
 if (NOT APPLE)
@@ -36,9 +56,9 @@ add_subdirectory(repeater)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
-if (NOT APPLE)
-find_package(OpenXR REQUIRED)
-endif(NOT APPLE)
+#if (NOT APPLE)
+#find_package(OpenXR REQUIRED)
+#endif(NOT APPLE)
 
 set(BC_SOURCES
     iprof.cpp
@@ -130,14 +150,19 @@ if (APPLE)
 else (APPLE)
     target_link_libraries(bridgecommand-bc PRIVATE
         bc-asio
-        enet
+        enet64
         bc-serial
-        bc-irrlicht
+        irrlicht #(instead of bc-irrlicht below)
+		#bc-irrlicht
         Threads::Threads
         sndfile
-        portaudio
-        asound
-        GL
-        OpenXR::openxr_loader
+        portaudio_x64
+        #asound
+        #GL
+        #OpenXR::openxr_loader
+        winmm
+        ws2_32
+        openxr_loader
+        opengl32.lib
     )
 endif (APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,13 +17,10 @@ endif (APPLE)
 if (WIN32)
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-endif (WIN32)
 
 add_subdirectory(libs/asio)
 add_subdirectory(libs/serial)
 include_directories("libs/enet-1.3.14/include")
-
-if (WIN32)
 include_directories(libs/libsndfile/include)
 include_directories(libs/portaudio/include)
 include_directories(libs/Irrlicht/irrlicht-svn/include)
@@ -35,9 +32,12 @@ LINK_DIRECTORIES(libs/enet-1.3.14)
 LINK_DIRECTORIES(libs/Irrlicht/irrlicht-svn/lib/Win64-visualstudio)
 LINK_DIRECTORIES(libs/OpenXR/OpenXR-SDK-main/build/win64/src/loader/Release)
 else (WIN32)
+add_subdirectory(libs/asio)
 add_subdirectory(libs/enet-1.3.14)
-#add_subdirectory(libs/Irrlicht)
-add_subdirectory(libs/OpenXR/OpenXR-SDK-main)
+add_subdirectory(libs/Irrlicht)
+add_subdirectory(libs/serial)
+
+include_directories("libs/enet-1.3.14/include")
 endif (WIN32)
 
 add_definitions(-DWITH_SOUND)
@@ -56,9 +56,9 @@ add_subdirectory(repeater)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
-#if (NOT APPLE)
-#find_package(OpenXR REQUIRED)
-#endif(NOT APPLE)
+if (NOT APPLE AND NOT WIN32)
+find_package(OpenXR REQUIRED)
+endif(NOT APPLE AND NOT WIN32)
 
 set(BC_SOURCES
     iprof.cpp
@@ -147,22 +147,31 @@ if (APPLE)
 	    "-framework AudioToolbox"
 	    "-framework CoreAudio"
     )
-else (APPLE)
+elseif (WIN32)
     target_link_libraries(bridgecommand-bc PRIVATE
         bc-asio
         enet64
         bc-serial
-        irrlicht #(instead of bc-irrlicht below)
-		#bc-irrlicht
+        irrlicht 
         Threads::Threads
         sndfile
         portaudio_x64
-        #asound
-        #GL
-        #OpenXR::openxr_loader
         winmm
         ws2_32
         openxr_loader
-        opengl32.lib
+        opengl32
     )
-endif (APPLE)
+else ()
+    target_link_libraries(bridgecommand-bc PRIVATE
+        bc-asio
+        enet
+        bc-serial
+        bc-irrlicht
+        Threads::Threads
+        sndfile
+        portaudio
+        asound
+        GL
+        OpenXR::openxr_loader
+    )
+endif ()

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -19,8 +19,11 @@ find_package(Threads REQUIRED)
 
 target_link_libraries(bridgecommand-mc
     bc-asio
-    enet
-    bc-irrlicht
+    enet64
+    #bc-irrlicht
+    irrlicht
     bc-aisparser
     Threads::Threads
+    winmm
+    ws2_32
 )

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -17,13 +17,22 @@ add_executable(bridgecommand-mc
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
 
+if (WIN32)
 target_link_libraries(bridgecommand-mc
     bc-asio
     enet64
-    #bc-irrlicht
     irrlicht
     bc-aisparser
     Threads::Threads
     winmm
     ws2_32
 )
+else ()
+target_link_libraries(bridgecommand-mc
+    bc-asio
+    enet
+    bc-irrlicht
+    bc-aisparser
+    Threads::Threads
+)
+endif ()

--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -14,5 +14,6 @@ add_executable(bridgecommand-ed
 
 
 target_link_libraries(bridgecommand-ed
-    bc-irrlicht
+    #bc-irrlicht
+    irrlicht
 )

--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -12,8 +12,12 @@ add_executable(bridgecommand-ed
     StartupEventReceiver.cpp
 )
 
-
+if (WIN32)
 target_link_libraries(bridgecommand-ed
-    #bc-irrlicht
     irrlicht
 )
+else ()
+target_link_libraries(bridgecommand-ed
+    bc-irrlicht
+)
+endif ()

--- a/src/iniEditor/CMakeLists.txt
+++ b/src/iniEditor/CMakeLists.txt
@@ -7,5 +7,6 @@ add_executable(bridgecommand-ini
 )
 
 target_link_libraries(bridgecommand-ini
-    bc-irrlicht
+    #bc-irrlicht
+    irrlicht
 )

--- a/src/iniEditor/CMakeLists.txt
+++ b/src/iniEditor/CMakeLists.txt
@@ -6,7 +6,12 @@ add_executable(bridgecommand-ini
     ../Utilities.cpp
 )
 
+if (WIN32)
 target_link_libraries(bridgecommand-ini
-    #bc-irrlicht
     irrlicht
 )
+else ()
+target_link_libraries(bridgecommand-ini
+    bc-irrlicht
+)
+endif ()

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -7,5 +7,6 @@ add_executable(bridgecommand
 )
 
 target_link_libraries(bridgecommand
-    bc-irrlicht
+    #bc-irrlicht
+    irrlicht
 )

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -6,7 +6,12 @@ add_executable(bridgecommand
     ../Utilities.cpp
 )
 
+if (WIN32)
 target_link_libraries(bridgecommand
-    #bc-irrlicht
     irrlicht
 )
+else ()
+target_link_libraries(bridgecommand
+    bc-irrlicht
+)
+endif ()

--- a/src/multiplayerHub/CMakeLists.txt
+++ b/src/multiplayerHub/CMakeLists.txt
@@ -13,10 +13,17 @@ add_executable(bridgecommand-mh
     EventReceiver.cpp
 )
 
+if (WIN32)
 target_link_libraries(bridgecommand-mh
     enet64
-    #bc-irrlicht
     irrlicht
     winmm
     ws2_32
 )
+else ()
+target_link_libraries(bridgecommand-mh
+    enet
+    bc-irrlicht
+)
+endif ()
+

--- a/src/multiplayerHub/CMakeLists.txt
+++ b/src/multiplayerHub/CMakeLists.txt
@@ -14,6 +14,9 @@ add_executable(bridgecommand-mh
 )
 
 target_link_libraries(bridgecommand-mh
-    enet
-    bc-irrlicht
+    enet64
+    #bc-irrlicht
+    irrlicht
+    winmm
+    ws2_32
 )

--- a/src/repeater/CMakeLists.txt
+++ b/src/repeater/CMakeLists.txt
@@ -18,7 +18,10 @@ find_package(Threads REQUIRED)
 
 target_link_libraries(bridgecommand-rp
     bc-asio
-    enet
-    bc-irrlicht
+    enet64
+    #bc-irrlicht
+    irrlicht
     Threads::Threads
+    winmm
+    ws2_32
 )

--- a/src/repeater/CMakeLists.txt
+++ b/src/repeater/CMakeLists.txt
@@ -16,12 +16,21 @@ add_executable(bridgecommand-rp
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
 
+if (WIN32)
 target_link_libraries(bridgecommand-rp
     bc-asio
     enet64
-    #bc-irrlicht
     irrlicht
     Threads::Threads
     winmm
     ws2_32
 )
+else ()
+target_link_libraries(bridgecommand-rp
+    bc-asio
+    enet
+    bc-irrlicht
+    Threads::Threads
+)
+endif ()
+


### PR DESCRIPTION
Links to existing dll versions of Irrlicht, enet, libsndfile, portaudio, and OpenXR loader.